### PR TITLE
Initialize bullet flags for player and enemy hit detection

### DIFF
--- a/BulletHell/Models/Bullet.cs
+++ b/BulletHell/Models/Bullet.cs
@@ -134,6 +134,7 @@ public class Bullet : IDisposable
         _collider.Position = Position;
         _direction = direction;
         _timeAlive = 0f;
+        _hitEnemy = false;
     }
 
     protected virtual void Dispose(bool disposing)

--- a/BulletHell/Models/EnemyBullet.cs
+++ b/BulletHell/Models/EnemyBullet.cs
@@ -79,6 +79,7 @@ public class EnemyBullet : IDisposable
         _velocity = velocity;
         _timeAlive = 0f;
         _collider.Position = Position;
+        _hitPlayer = false;
     }
 
     public void Dispose()


### PR DESCRIPTION
The `_hitPlayer` and `_hitEnemy` flags have been initialized in the bullet models to support hit detection and ensure proper behavior during gameplay.